### PR TITLE
Assume HTTPS by default

### DIFF
--- a/Browser/Functions.vb
+++ b/Browser/Functions.vb
@@ -5,7 +5,7 @@ Module Functions
     Public Function UrlIsValid(ByVal url As String) As Boolean
         Dim is_valid As Boolean = False
         If url.ToLower().StartsWith("www.") Then url =
-            "http://" & url
+            "https://" & url
 
         Dim web_response As HttpWebResponse = Nothing
         Try


### PR DESCRIPTION
If a user types `www.` in the field, let's assume it's an HTTPS, only a small amount of sites do not support HTTPS these days, and the majority of sites users remember (like www.google.com, gmail.com, etc) and don't access through Google support HTTP. Thoughts?